### PR TITLE
fix: replace binary pwa icons with svg assets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+NEXT_PUBLIC_CLUBS_URL=https://app.nocodb.com/api/v2/views/b568bf5d-8c1e-4e2d-94bd-12f1fc7b5dcf/records
+NEXT_PUBLIC_WORKOUTS_URL=https://app.nocodb.com/api/v2/views/1cf6ade5-f84c-4bed-9d73-7bc530024c16/records
+NEXT_PUBLIC_RACES_URL=https://app.nocodb.com/api/v2/views/b1b5582b-7cb4-4e96-8938-ada0d2a50f21/records
+NEXT_PUBLIC_ROUTES_URL=https://app.nocodb.com/api/v2/views/658ff60c-106e-4731-b979-ad66de45bdcc/records
+NEXT_PUBLIC_CLUB_FORM_URL=https://app.nocodb.com/#/nc/form/7a1f8ac9-5fcd-4937-93f6-951d8f8f2698
+NEXT_PUBLIC_RUN_FORM_URL=https://app.nocodb.com/#/nc/form/ed113894-be33-4ca0-854f-84eb321ebf7f
+# Заполните, если используется приватный доступ NocoDB
+NOCODB_TOKEN=

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+node_modules
+.next
+out
+.env
+.DS_Store
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.pnpm-debug.log*
+
+# Local editor settings
+.vscode
+.idea

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "none",
+  "printWidth": 100
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
-# runclubs-platform
-Ololo
+# RunClubs
+
+Минималистичный русскоязычный сайт для бегового комьюнити. Приложение построено на Next.js 14 (App Router) с
+TypeScript и Tailwind CSS. Данные подгружаются из публичных представлений NocoDB, при наличии `NOCODB_TOKEN`
+используется серверный прокси с заголовком `xc-token`.
+
+## Стек
+
+- Next.js 14 + App Router
+- TypeScript
+- Tailwind CSS
+- SWR для клиентского кеширования
+- PWA-манифест и сервис-воркер для офлайн-доступа
+
+## Переменные окружения
+
+Создайте файл `.env` на основе примера:
+
+```bash
+cp .env.example .env
+```
+
+Список переменных:
+
+- `NEXT_PUBLIC_CLUBS_URL`
+- `NEXT_PUBLIC_WORKOUTS_URL`
+- `NEXT_PUBLIC_RACES_URL`
+- `NEXT_PUBLIC_ROUTES_URL`
+- `NEXT_PUBLIC_CLUB_FORM_URL`
+- `NEXT_PUBLIC_RUN_FORM_URL`
+- `NOCODB_TOKEN` (опционально, только если нужен приватный доступ к API)
+
+## Запуск локально
+
+```bash
+npm install
+npm run dev
+```
+
+Приложение будет доступно по адресу [http://localhost:3000](http://localhost:3000).
+
+## Сборка
+
+```bash
+npm run build
+```
+
+## Деплой на Vercel
+
+1. Создайте новый проект в Vercel и подключите репозиторий.
+2. В разделе **Environment Variables** добавьте переменные из `.env`.
+3. Запустите деплой — Vercel автоматически соберёт и опубликует приложение.
+
+После деплоя убедитесь, что на главной странице отображаются данные и корректно работает фильтр города.

--- a/app/api/noco/route.ts
+++ b/app/api/noco/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+
+const KIND_TO_ENV: Record<string, string> = {
+  clubs: 'NEXT_PUBLIC_CLUBS_URL',
+  workouts: 'NEXT_PUBLIC_WORKOUTS_URL',
+  races: 'NEXT_PUBLIC_RACES_URL',
+  routes: 'NEXT_PUBLIC_ROUTES_URL'
+};
+
+export async function GET(request: Request) {
+  if (!process.env.NOCODB_TOKEN) {
+    return NextResponse.json(
+      { error: 'NOCODB_TOKEN is not configured' },
+      { status: 500 }
+    );
+  }
+
+  const { searchParams } = new URL(request.url);
+  const kind = searchParams.get('kind');
+
+  if (!kind || !(kind in KIND_TO_ENV)) {
+    return NextResponse.json({ error: 'Unknown dataset kind' }, { status: 400 });
+  }
+
+  const baseUrl = process.env[KIND_TO_ENV[kind]];
+
+  if (!baseUrl) {
+    return NextResponse.json({ error: 'Source URL is not configured' }, { status: 500 });
+  }
+
+  const targetUrl = new URL(baseUrl);
+
+  searchParams.delete('kind');
+  searchParams.forEach((value, key) => {
+    if (value) {
+      targetUrl.searchParams.set(key, value);
+    }
+  });
+
+  const response = await fetch(targetUrl.toString(), {
+    headers: {
+      'xc-token': process.env.NOCODB_TOKEN,
+      accept: 'application/json'
+    },
+    next: { revalidate: 0 }
+  });
+
+  if (!response.ok) {
+    return NextResponse.json({ error: 'Failed to fetch data' }, { status: response.status });
+  }
+
+  const data = await response.json();
+  return NextResponse.json(data);
+}

--- a/app/clubs/page.tsx
+++ b/app/clubs/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+import { ClubsCatalog } from '@/components/catalog/clubs-catalog';
+
+export const metadata: Metadata = {
+  title: 'Беговые клубы — RunClubs',
+  description: 'Каталог проверенных беговых клубов и тренеров в России.'
+};
+
+export default function ClubsPage() {
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-4xl font-semibold tracking-tight">Каталог беговых клубов</h1>
+        <p className="max-w-2xl text-base text-ink/70">
+          Найдите своё беговое комьюнити, тренера и регулярные тренировки. Используйте фильтр города в шапке,
+          чтобы увидеть клубы рядом с вами.
+        </p>
+      </header>
+      <ClubsCatalog />
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,19 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-background text-ink font-sans antialiased;
+}
+
+a {
+  @apply text-ink;
+}
+
+.section-grid {
+  @apply grid gap-6 sm:grid-cols-2 lg:grid-cols-3;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,61 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import { Inter } from 'next/font/google';
+import './globals.css';
+import { Providers } from '@/components/providers/providers';
+import { Header } from '@/components/layout/header';
+
+const inter = Inter({
+  subsets: ['latin', 'cyrillic'],
+  variable: '--font-inter'
+});
+
+export const metadata: Metadata = {
+  title: 'RunClubs — беговые клубы и тренировки',
+  description:
+    'RunClubs помогает найти беговой клуб, тренировку, забег или маршрут в вашем городе.',
+  metadataBase: new URL('https://runclubs.example'),
+  openGraph: {
+    title: 'RunClubs — беговые клубы и тренировки',
+    description:
+      'Подборка лучших клубов, маршрутов и забегов для бегового комьюнити России.',
+    locale: 'ru_RU',
+    siteName: 'RunClubs',
+    type: 'website'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'RunClubs — беговые клубы и тренировки',
+    description:
+      'Подборка лучших клубов, маршрутов и забегов для бегового комьюнити России.'
+  },
+  alternates: {
+    canonical: '/' 
+  },
+  icons: {
+    icon: '/favicon.svg',
+    shortcut: '/favicon.svg',
+    apple: '/icon-192.svg'
+  },
+  manifest: '/manifest.webmanifest',
+  themeColor: '#F9F9F7'
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: ReactNode;
+}) {
+  return (
+    <html lang="ru" className={inter.variable}>
+      <body>
+        <Providers>
+          <Header />
+          <main className="mx-auto w-full max-w-6xl px-4 pb-24 pt-8 sm:px-6 lg:px-8">
+            {children}
+          </main>
+        </Providers>
+      </body>
+    </html>
+  );
+}

--- a/app/manifest.webmanifest
+++ b/app/manifest.webmanifest
@@ -1,0 +1,23 @@
+{
+  "name": "RunClubs",
+  "short_name": "RunClubs",
+  "lang": "ru",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#F9F9F7",
+  "theme_color": "#0077FF",
+  "icons": [
+    {
+      "src": "/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    }
+  ]
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,44 @@
+import { CTASection } from '@/components/sections/cta-section';
+import { RoutesSection } from '@/components/sections/routes-section';
+import { TopClubsSection } from '@/components/sections/top-clubs-section';
+import { UpcomingRacesSection } from '@/components/sections/upcoming-races-section';
+import { WeekendWorkoutsSection } from '@/components/sections/weekend-workouts-section';
+
+export default function HomePage() {
+  return (
+    <div className="space-y-16">
+      <section className="rounded-3xl bg-white px-6 py-16 shadow-soft sm:px-12">
+        <div className="flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+          <div className="space-y-4">
+            <span className="inline-flex rounded-full bg-accent/60 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-ink">
+              Беговое комьюнити
+            </span>
+            <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">
+              RunClubs — карта клубов, тренировок и забегов
+            </h1>
+            <p className="max-w-2xl text-lg text-ink/70">
+              Мы собираем в одном месте афишу выходных, подборку проверенных клубов и маршруты для пробежек в
+              городах России. Выбирайте свой темп и присоединяйтесь к движению.
+            </p>
+          </div>
+          <dl className="grid grid-cols-2 gap-4 text-sm text-ink/70 md:w-72">
+            <div>
+              <dt className="font-semibold text-ink">>50 клубов</dt>
+              <dd>Только проверенные сообщества с открытыми тренерами.</dd>
+            </div>
+            <div>
+              <dt className="font-semibold text-ink">Маршруты</dt>
+              <dd>Лучшие дорожки для утренних и вечерних пробежек.</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+
+      <WeekendWorkoutsSection />
+      <TopClubsSection />
+      <UpcomingRacesSection />
+      <RoutesSection />
+      <CTASection />
+    </div>
+  );
+}

--- a/app/races/page.tsx
+++ b/app/races/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import { RacesCatalog } from '@/components/catalog/races-catalog';
+
+export const metadata: Metadata = {
+  title: 'Календарь забегов — RunClubs',
+  description: 'Календарь ближайших стартов и забегов в выбранном городе.'
+};
+
+export default function RacesPage() {
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-4xl font-semibold tracking-tight">Ближайшие забеги</h1>
+        <p className="max-w-2xl text-base text-ink/70">
+          Планируйте участие в стартах и следите за календарем забегов в вашем городе.
+        </p>
+      </header>
+      <RacesCatalog />
+    </div>
+  );
+}

--- a/app/routes/page.tsx
+++ b/app/routes/page.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import { RoutesCatalog } from '@/components/catalog/routes-catalog';
+
+export const metadata: Metadata = {
+  title: 'Маршруты для пробежек — RunClubs',
+  description: 'Подборка проверенных беговых маршрутов в городах России.'
+};
+
+export default function RoutesPage() {
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-4xl font-semibold tracking-tight">Маршруты для пробежек</h1>
+        <p className="max-w-2xl text-base text-ink/70">
+          Исследуйте популярные и живописные маршруты для утренних и вечерних пробежек.
+        </p>
+      </header>
+      <RoutesCatalog />
+    </div>
+  );
+}

--- a/app/workouts/page.tsx
+++ b/app/workouts/page.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from 'next';
+import { WorkoutsCatalog } from '@/components/catalog/workouts-catalog';
+
+export const metadata: Metadata = {
+  title: 'Тренировки и пробежки — RunClubs',
+  description: 'Актуальная афиша совместных пробежек и открытых тренировок в городах России.'
+};
+
+export default function WorkoutsPage() {
+  return (
+    <div className="space-y-8">
+      <header className="space-y-2">
+        <h1 className="text-4xl font-semibold tracking-tight">Афиша тренировок</h1>
+        <p className="max-w-2xl text-base text-ink/70">
+          Выбирайте ближайшие пробежки по темпу и формату. Переключайтесь на «только открытые», чтобы видеть
+          мероприятия без предварительной записи.
+        </p>
+      </header>
+      <WorkoutsCatalog />
+    </div>
+  );
+}

--- a/components/cards/club-card.tsx
+++ b/components/cards/club-card.tsx
@@ -1,0 +1,25 @@
+import Image from 'next/image';
+import type { ClubRecord } from '@/lib/types';
+
+export function ClubCard({ club }: { club: ClubRecord }) {
+  return (
+    <article className="flex h-full flex-col overflow-hidden rounded-2xl bg-white shadow-soft">
+      {club.photoUrl ? (
+        <div className="relative h-48 w-full overflow-hidden">
+          <Image
+            src={club.photoUrl}
+            alt={club.name}
+            fill
+            sizes="(max-width: 768px) 100vw, 33vw"
+            className="object-cover"
+          />
+        </div>
+      ) : null}
+      <div className="flex flex-1 flex-col gap-3 p-6">
+        <h3 className="text-lg font-semibold">{club.name}</h3>
+        <p className="text-sm text-ink/60">{club.city}</p>
+        {club.description ? <p className="mt-auto text-sm text-ink/70">{club.description}</p> : null}
+      </div>
+    </article>
+  );
+}

--- a/components/cards/race-card.tsx
+++ b/components/cards/race-card.tsx
@@ -1,0 +1,14 @@
+import type { RaceRecord } from '@/lib/types';
+import { formatDate } from '@/lib/utils';
+
+export function RaceCard({ race }: { race: RaceRecord }) {
+  return (
+    <li className="flex flex-col gap-2 rounded-2xl bg-white p-5 shadow-soft sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <p className="text-sm text-ink/60">{race.city ?? 'Город уточняется'}</p>
+        <h3 className="text-lg font-semibold">{race.title}</h3>
+      </div>
+      <p className="text-sm font-medium text-ink/80">{formatDate(race.date)}</p>
+    </li>
+  );
+}

--- a/components/cards/route-card.tsx
+++ b/components/cards/route-card.tsx
@@ -1,0 +1,16 @@
+import type { RouteRecord } from '@/lib/types';
+import { formatDistance } from '@/lib/utils';
+
+export function RouteCard({ route }: { route: RouteRecord }) {
+  const distance = formatDistance(route.distanceKm ?? undefined);
+  return (
+    <article className="flex h-full flex-col gap-3 rounded-2xl bg-white p-6 shadow-soft">
+      <h3 className="text-lg font-semibold">{route.title}</h3>
+      <p className="text-sm text-ink/60">{route.city ?? 'Город уточняется'}</p>
+      <div className="mt-auto flex flex-wrap gap-2 text-sm text-ink/70">
+        {distance ? <span className="rounded-full bg-ink/5 px-3 py-1">{distance}</span> : null}
+        {route.surface ? <span className="rounded-full bg-ink/5 px-3 py-1">{route.surface}</span> : null}
+      </div>
+    </article>
+  );
+}

--- a/components/cards/workout-card.tsx
+++ b/components/cards/workout-card.tsx
@@ -1,0 +1,28 @@
+import { Badge } from '@/components/ui/badge';
+import type { WorkoutRecord } from '@/lib/types';
+import { formatDateWithWeekday, formatDistance, formatPace } from '@/lib/utils';
+
+export function WorkoutCard({ workout }: { workout: WorkoutRecord }) {
+  const date = formatDateWithWeekday(workout.date);
+  const distance = formatDistance(workout.distanceKm ?? undefined);
+  const pace = formatPace(workout.paceMin ?? undefined, workout.paceMax ?? undefined);
+
+  return (
+    <article className="flex h-full flex-col justify-between gap-4 rounded-2xl bg-white p-6 shadow-soft">
+      <div className="flex flex-wrap items-center gap-2 text-sm text-ink/60">
+        <span className="font-semibold text-ink">{date}</span>
+        {workout.city ? <span>· {workout.city}</span> : null}
+        {workout.isOpen ? <Badge className="bg-accent/30 text-xs text-ink">Открыта</Badge> : null}
+      </div>
+      <div className="space-y-2">
+        <h3 className="text-lg font-semibold">{workout.title ?? 'Совместная тренировка'}</h3>
+        {workout.clubName ? <p className="text-sm text-ink/70">{workout.clubName}</p> : null}
+        {workout.location ? <p className="text-sm text-ink/70">{workout.location}</p> : null}
+      </div>
+      <div className="mt-auto flex flex-wrap gap-3 text-sm text-ink/70">
+        {distance ? <span className="rounded-full bg-ink/5 px-3 py-1">{distance}</span> : null}
+        {pace ? <span className="rounded-full bg-ink/5 px-3 py-1">{pace}</span> : null}
+      </div>
+    </article>
+  );
+}

--- a/components/catalog/clubs-catalog.tsx
+++ b/components/catalog/clubs-catalog.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { ClubCard } from '@/components/cards/club-card';
+import { EmptyState } from '@/components/ui/empty-state';
+import { Loader } from '@/components/ui/loader';
+import { useCity } from '@/components/ui/city-select';
+import { fetchRecords } from '@/lib/api';
+import { filterByCitySelection } from '@/lib/cities';
+import type { ClubRecord } from '@/lib/types';
+
+const clubFormUrl = process.env.NEXT_PUBLIC_CLUB_FORM_URL ?? '#';
+
+export function ClubsCatalog() {
+  const { value, cityName } = useCity();
+  const { data, error, isLoading } = useSWR(['clubs-catalog', value], async () => {
+    const response = await fetchRecords<ClubRecord>('clubs', cityName ?? undefined);
+    return response.list;
+  });
+
+  const clubs = useMemo(() => {
+    if (!data) return [];
+    return filterByCitySelection(data, value);
+  }, [data, value]);
+
+  if (isLoading) {
+    return <Loader />;
+  }
+
+  if (error) {
+    return <EmptyState title="Не удалось загрузить клубы" description="Попробуйте обновить страницу позднее." />;
+  }
+
+  if (clubs.length === 0) {
+    return (
+      <EmptyState
+        title="Клубы не найдены"
+        description="Мы еще не знаем клубов в этом городе. Оставьте заявку, чтобы появиться первыми."
+        action={
+          <EmptyState.ActionButton asChild>
+            <a href={clubFormUrl} target="_blank" rel="noopener noreferrer">
+              Добавить клуб
+            </a>
+          </EmptyState.ActionButton>
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="section-grid">
+      {clubs.map((club) => (
+        <ClubCard key={club.id} club={club} />
+      ))}
+    </div>
+  );
+}

--- a/components/catalog/races-catalog.tsx
+++ b/components/catalog/races-catalog.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { RaceCard } from '@/components/cards/race-card';
+import { EmptyState } from '@/components/ui/empty-state';
+import { Loader } from '@/components/ui/loader';
+import { useCity } from '@/components/ui/city-select';
+import { fetchRecords } from '@/lib/api';
+import { filterByCitySelection } from '@/lib/cities';
+import type { RaceRecord } from '@/lib/types';
+
+export function RacesCatalog() {
+  const { value, cityName } = useCity();
+  const { data, error, isLoading } = useSWR(['races-catalog', value], async () => {
+    const response = await fetchRecords<RaceRecord>('races', cityName ?? undefined, {
+      sort: 'date'
+    });
+    return response.list;
+  });
+
+  const races = useMemo(() => {
+    if (!data) return [];
+    const filtered = filterByCitySelection(data, value);
+    return [...filtered].sort((a, b) => {
+      const aTime = a.date ? new Date(a.date).getTime() : Number.MAX_SAFE_INTEGER;
+      const bTime = b.date ? new Date(b.date).getTime() : Number.MAX_SAFE_INTEGER;
+      return aTime - bTime;
+    });
+  }, [data, value]);
+
+  if (isLoading) {
+    return <Loader />;
+  }
+
+  if (error) {
+    return <EmptyState title="Не удалось загрузить забеги" description="Попробуйте обновить страницу позже." />;
+  }
+
+  if (races.length === 0) {
+    return <EmptyState title="Забегов пока нет" description="Следите за обновлениями календаря." />;
+  }
+
+  return (
+    <ul className="flex flex-col gap-4">
+      {races.map((race) => (
+        <RaceCard key={race.id} race={race} />
+      ))}
+    </ul>
+  );
+}

--- a/components/catalog/routes-catalog.tsx
+++ b/components/catalog/routes-catalog.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { RouteCard } from '@/components/cards/route-card';
+import { EmptyState } from '@/components/ui/empty-state';
+import { Loader } from '@/components/ui/loader';
+import { useCity } from '@/components/ui/city-select';
+import { fetchRecords } from '@/lib/api';
+import { filterByCitySelection } from '@/lib/cities';
+import type { RouteRecord } from '@/lib/types';
+
+const runFormUrl = process.env.NEXT_PUBLIC_RUN_FORM_URL ?? '#';
+
+export function RoutesCatalog() {
+  const { value, cityName } = useCity();
+  const { data, error, isLoading } = useSWR(['routes-catalog', value], async () => {
+    const response = await fetchRecords<RouteRecord>('routes', cityName ?? undefined);
+    return response.list;
+  });
+
+  const routes = useMemo(() => {
+    if (!data) return [];
+    return filterByCitySelection(data, value);
+  }, [data, value]);
+
+  if (isLoading) {
+    return <Loader />;
+  }
+
+  if (error) {
+    return <EmptyState title="Не удалось загрузить маршруты" description="Повторите попытку позже." />;
+  }
+
+  if (routes.length === 0) {
+    return (
+      <EmptyState
+        title="Маршруты не найдены"
+        description="Расскажите о своей пробежке и помогите бегунам открыть новое место."
+        action={
+          <EmptyState.ActionButton asChild>
+            <a href={runFormUrl} target="_blank" rel="noopener noreferrer">
+              Поделиться маршрутом
+            </a>
+          </EmptyState.ActionButton>
+        }
+      />
+    );
+  }
+
+  return (
+    <div className="section-grid">
+      {routes.map((route) => (
+        <RouteCard key={route.id} route={route} />
+      ))}
+    </div>
+  );
+}

--- a/components/catalog/workouts-catalog.tsx
+++ b/components/catalog/workouts-catalog.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import useSWR from 'swr';
+import { WorkoutCard } from '@/components/cards/workout-card';
+import { Button } from '@/components/ui/button';
+import { EmptyState } from '@/components/ui/empty-state';
+import { Loader } from '@/components/ui/loader';
+import { useCity } from '@/components/ui/city-select';
+import { fetchRecords } from '@/lib/api';
+import { filterByCitySelection } from '@/lib/cities';
+import type { WorkoutRecord } from '@/lib/types';
+
+const runFormUrl = process.env.NEXT_PUBLIC_RUN_FORM_URL ?? '#';
+
+export function WorkoutsCatalog() {
+  const [onlyOpen, setOnlyOpen] = useState(false);
+  const { value, cityName } = useCity();
+  const { data, error, isLoading } = useSWR(['workouts-catalog', value], async () => {
+    const response = await fetchRecords<WorkoutRecord>('workouts', cityName ?? undefined);
+    return response.list;
+  });
+
+  const workouts = useMemo(() => {
+    if (!data) return [];
+    const filtered = filterByCitySelection(data, value);
+    if (!onlyOpen) return filtered;
+    return filtered.filter((workout) => workout.isOpen);
+  }, [data, value, onlyOpen]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          variant={onlyOpen ? 'primary' : 'ghost'}
+          onClick={() => setOnlyOpen((prev) => !prev)}
+          className={onlyOpen ? '' : 'border border-ink/10'}
+        >
+          Только открытые
+        </Button>
+      </div>
+
+      {isLoading ? <Loader /> : null}
+      {error ? <EmptyState title="Не удалось загрузить тренировки" description="Повторите попытку позже." /> : null}
+
+      {!isLoading && !error ? (
+        workouts.length > 0 ? (
+          <div className="section-grid">
+            {workouts.map((workout) => (
+              <WorkoutCard key={workout.id} workout={workout} />
+            ))}
+          </div>
+        ) : (
+          <EmptyState
+            title="Тренировки не найдены"
+            description="Расскажите о своей пробежке, чтобы попасть в афишу."
+            action={
+              <EmptyState.ActionButton asChild>
+                <a href={runFormUrl} target="_blank" rel="noopener noreferrer">
+                  Предложить тренировку
+                </a>
+              </EmptyState.ActionButton>
+            }
+          />
+        )
+      ) : null}
+    </div>
+  );
+}

--- a/components/layout/header.tsx
+++ b/components/layout/header.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import clsx from 'clsx';
+import { CitySelect } from '@/components/ui/city-select';
+import { Button } from '@/components/ui/button';
+
+const links = [
+  { href: '/clubs', label: 'Клубы' },
+  { href: '/workouts', label: 'Тренировки' },
+  { href: '/races', label: 'Забеги' },
+  { href: '/routes', label: 'Маршруты' }
+];
+
+export function Header() {
+  const pathname = usePathname();
+
+  return (
+    <header className="border-b border-white/20 bg-background/80 backdrop-blur">
+      <div className="mx-auto flex w-full max-w-6xl flex-col gap-4 px-4 py-6 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
+        <div className="flex items-center justify-between gap-8">
+          <Link href="/" className="text-xl font-semibold tracking-tight">
+            RunClubs
+          </Link>
+          <nav className="hidden items-center gap-4 text-sm font-medium sm:flex">
+            {links.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className={clsx(
+                  'rounded-full px-3 py-1 transition-colors duration-150',
+                  pathname === link.href
+                    ? 'bg-ink text-background'
+                    : 'hover:bg-ink/5'
+                )}
+              >
+                {link.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+        <div className="flex items-center gap-3">
+          <CitySelect />
+          <Button asChild variant="outline" className="sm:hidden">
+            <Link href="/workouts">Афиша</Link>
+          </Button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/components/providers/providers.tsx
+++ b/components/providers/providers.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { useEffect, type ReactNode } from 'react';
+import { SWRConfig } from 'swr';
+import { CityProvider } from '@/components/ui/city-select';
+import { fetchJson } from '@/lib/api';
+
+export function Providers({ children }: { children: ReactNode }) {
+  useEffect(() => {
+    if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
+      const register = async () => {
+        try {
+          await navigator.serviceWorker.register('/sw.js');
+        } catch (error) {
+          console.error('SW registration failed', error);
+        }
+      };
+
+      if (document.readyState === 'complete') {
+        register();
+      } else {
+        window.addEventListener('load', register, { once: true });
+      }
+    }
+  }, []);
+
+  return (
+    <CityProvider>
+      <SWRConfig value={{ fetcher: (resource: string) => fetchJson(resource), revalidateOnFocus: false }}>
+        {children}
+      </SWRConfig>
+    </CityProvider>
+  );
+}

--- a/components/sections/cta-section.tsx
+++ b/components/sections/cta-section.tsx
@@ -1,0 +1,37 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+
+const clubFormUrl = process.env.NEXT_PUBLIC_CLUB_FORM_URL ?? '#';
+const runFormUrl = process.env.NEXT_PUBLIC_RUN_FORM_URL ?? '#';
+
+export function CTASection() {
+  return (
+    <section className="mt-16 rounded-3xl bg-ink text-background">
+      <div className="flex flex-col gap-6 px-8 py-12 sm:px-12 sm:py-16 md:flex-row md:items-center md:justify-between">
+        <div className="space-y-4">
+          <h2 className="text-3xl font-semibold sm:text-4xl">Присоединяйтесь к RunClubs</h2>
+          <p className="max-w-xl text-base text-white/80">
+            Добавьте свой клуб или предложите открытую пробежку — мы поможем рассказать о вас беговому
+            комьюнити в России.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3">
+          <Button asChild>
+            <Link href={clubFormUrl} target="_blank" rel="noopener noreferrer">
+              Заявка на клуб
+            </Link>
+          </Button>
+          <Button
+            asChild
+            variant="ghost"
+            className="border border-white/30 text-background hover:bg-white/10"
+          >
+            <Link href={runFormUrl} target="_blank" rel="noopener noreferrer">
+              Предложить пробежку
+            </Link>
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/sections/routes-section.tsx
+++ b/components/sections/routes-section.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { RouteCard } from '@/components/cards/route-card';
+import { Loader } from '@/components/ui/loader';
+import { EmptyState } from '@/components/ui/empty-state';
+import { Section } from '@/components/ui/section';
+import { useCity } from '@/components/ui/city-select';
+import { fetchRecords } from '@/lib/api';
+import { filterByCitySelection } from '@/lib/cities';
+import type { RouteRecord } from '@/lib/types';
+
+export function RoutesSection() {
+  const { value, cityName } = useCity();
+  const { data, error, isLoading } = useSWR(['routes', value], async () => {
+    const response = await fetchRecords<RouteRecord>('routes', cityName ?? undefined);
+    return response.list;
+  });
+
+  const routes = useMemo(() => {
+    if (!data) return [];
+    return filterByCitySelection(data, value).slice(0, 6);
+  }, [data, value]);
+
+  return (
+    <Section title="Маршруты по городам" description="Подборки живописных дорожек для ваших пробежек">
+      {isLoading ? <Loader /> : null}
+      {error ? <EmptyState title="Не удалось загрузить маршруты" description="Попробуйте перезагрузить страницу." /> : null}
+      {!isLoading && !error ? (
+        routes.length > 0 ? (
+          <div className="section-grid">
+            {routes.map((route) => (
+              <RouteCard key={route.id} route={route} />
+            ))}
+          </div>
+        ) : (
+          <EmptyState title="Маршруты появятся скоро" description="Расскажите о своих любимых местах через форму ниже." />
+        )
+      ) : null}
+    </Section>
+  );
+}

--- a/components/sections/top-clubs-section.tsx
+++ b/components/sections/top-clubs-section.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { ClubCard } from '@/components/cards/club-card';
+import { Loader } from '@/components/ui/loader';
+import { EmptyState } from '@/components/ui/empty-state';
+import { Section } from '@/components/ui/section';
+import { useCity } from '@/components/ui/city-select';
+import { fetchRecords } from '@/lib/api';
+import { filterByCitySelection } from '@/lib/cities';
+import type { ClubRecord } from '@/lib/types';
+
+export function TopClubsSection() {
+  const { value, cityName } = useCity();
+  const { data, error, isLoading } = useSWR(['clubs', value], async () => {
+    const response = await fetchRecords<ClubRecord>('clubs', cityName ?? undefined);
+    return response.list;
+  });
+
+  const clubs = useMemo(() => {
+    if (!data) return [];
+    return filterByCitySelection(data, value).slice(0, 6);
+  }, [data, value]);
+
+  return (
+    <Section title="Топ клубов города" description="Отобранные комьюнити и проверенные тренеры">
+      {isLoading ? <Loader /> : null}
+      {error ? <EmptyState title="Не удалось загрузить клубы" description="Обновите страницу и попробуйте снова." /> : null}
+      {!isLoading && !error ? (
+        clubs.length > 0 ? (
+          <div className="section-grid">
+            {clubs.map((club) => (
+              <ClubCard key={club.id} club={club} />
+            ))}
+          </div>
+        ) : (
+          <EmptyState title="Клубы не найдены" description="Добавьте свой клуб через форму ниже." />
+        )
+      ) : null}
+    </Section>
+  );
+}

--- a/components/sections/upcoming-races-section.tsx
+++ b/components/sections/upcoming-races-section.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { RaceCard } from '@/components/cards/race-card';
+import { Loader } from '@/components/ui/loader';
+import { EmptyState } from '@/components/ui/empty-state';
+import { Section } from '@/components/ui/section';
+import { useCity } from '@/components/ui/city-select';
+import { fetchRecords } from '@/lib/api';
+import { filterByCitySelection } from '@/lib/cities';
+import type { RaceRecord } from '@/lib/types';
+
+export function UpcomingRacesSection() {
+  const { value, cityName } = useCity();
+  const { data, error, isLoading } = useSWR(['races', value], async () => {
+    const response = await fetchRecords<RaceRecord>('races', cityName ?? undefined, {
+      sort: 'date'
+    });
+    return response.list;
+  });
+
+  const races = useMemo(() => {
+    if (!data) return [];
+    const filtered = filterByCitySelection(data, value);
+    return [...filtered].sort((a, b) => {
+      const aTime = a.date ? new Date(a.date).getTime() : Number.MAX_SAFE_INTEGER;
+      const bTime = b.date ? new Date(b.date).getTime() : Number.MAX_SAFE_INTEGER;
+      return aTime - bTime;
+    });
+  }, [data, value]);
+
+  return (
+    <Section title="Ближайшие забеги" description="Собираемся на старты в вашем городе">
+      {isLoading ? <Loader /> : null}
+      {error ? <EmptyState title="Не удалось загрузить забеги" description="Попробуйте обновить страницу." /> : null}
+      {!isLoading && !error ? (
+        races.length > 0 ? (
+          <ul className="flex flex-col gap-4">
+            {races.map((race) => (
+              <RaceCard key={race.id} race={race} />
+            ))}
+          </ul>
+        ) : (
+          <EmptyState title="Забегов пока нет" description="Следите за обновлениями афиши." />
+        )
+      ) : null}
+    </Section>
+  );
+}

--- a/components/sections/weekend-workouts-section.tsx
+++ b/components/sections/weekend-workouts-section.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import { useMemo } from 'react';
+import useSWR from 'swr';
+import { WorkoutCard } from '@/components/cards/workout-card';
+import { Loader } from '@/components/ui/loader';
+import { EmptyState } from '@/components/ui/empty-state';
+import { Section } from '@/components/ui/section';
+import { useCity } from '@/components/ui/city-select';
+import { fetchRecords } from '@/lib/api';
+import { filterByCitySelection } from '@/lib/cities';
+import type { WorkoutRecord } from '@/lib/types';
+
+export function WeekendWorkoutsSection() {
+  const { value, cityName } = useCity();
+  const { data, error, isLoading } = useSWR(['workouts', value], async () => {
+    const response = await fetchRecords<WorkoutRecord>('workouts', cityName ?? undefined);
+    return response.list;
+  });
+
+  const workouts = useMemo(() => {
+    if (!data) return [];
+    return filterByCitySelection(data, value);
+  }, [data, value]);
+
+  return (
+    <Section title="Афиша выходных" description="Совместные забеги и тренировки ближайших выходных">
+      {isLoading ? <Loader /> : null}
+      {error ? <EmptyState title="Не удалось загрузить данные" description="Попробуйте обновить страницу." /> : null}
+      {!isLoading && !error ? (
+        workouts.length > 0 ? (
+          <div className="section-grid">
+            {workouts.map((workout) => (
+              <WorkoutCard key={workout.id} workout={workout} />
+            ))}
+          </div>
+        ) : (
+          <EmptyState title="Пока нет событий" description="Здесь появятся тренировки по выбранному направлению." />
+        )
+      ) : null}
+    </Section>
+  );
+}

--- a/components/ui/badge.tsx
+++ b/components/ui/badge.tsx
@@ -1,0 +1,14 @@
+import type { HTMLAttributes } from 'react';
+import clsx from 'clsx';
+
+export function Badge({ className, ...props }: HTMLAttributes<HTMLSpanElement>) {
+  return (
+    <span
+      className={clsx(
+        'inline-flex items-center rounded-full bg-ink/5 px-3 py-1 text-xs font-medium uppercase tracking-wide text-ink/70',
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { forwardRef, isValidElement, cloneElement } from 'react';
+import type { ButtonHTMLAttributes, ReactElement } from 'react';
+import clsx from 'clsx';
+
+type Variant = 'primary' | 'ghost' | 'outline';
+
+type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  variant?: Variant;
+  asChild?: boolean;
+};
+
+const baseStyles =
+  'inline-flex items-center justify-center rounded-full px-5 py-2 text-sm font-semibold transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ink/50 disabled:cursor-not-allowed disabled:opacity-60';
+
+const variantStyles: Record<Variant, string> = {
+  primary: 'bg-accentBlue text-white hover:bg-accentBlue/90',
+  ghost: 'bg-transparent text-ink hover:bg-ink/5',
+  outline: 'border border-ink/15 bg-white text-ink hover:border-ink/30 shadow-soft'
+};
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  { className, variant = 'primary', asChild, children, type = 'button', ...props },
+  ref
+) {
+  const classes = clsx(baseStyles, variantStyles[variant], className);
+
+  if (asChild && isValidElement(children)) {
+    const { type: _type, ...restProps } = props;
+    return cloneElement(children as ReactElement, {
+      ...restProps,
+      className: clsx((children as ReactElement).props.className, classes)
+    });
+  }
+
+  return (
+    <button ref={ref} className={classes} type={type} {...props}>
+      {children}
+    </button>
+  );
+});

--- a/components/ui/city-select.tsx
+++ b/components/ui/city-select.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { createContext, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+import clsx from 'clsx';
+import { CITY_OPTIONS, cityValueToName, type CityValue } from '@/lib/cities';
+
+const STORAGE_KEY = 'runclubs-city';
+
+type CityContextValue = {
+  value: CityValue;
+  cityName?: string;
+  setValue: (value: CityValue) => void;
+};
+
+const CityContext = createContext<CityContextValue | undefined>(undefined);
+
+function getInitialValue(): CityValue {
+  if (typeof window === 'undefined') {
+    return 'moscow';
+  }
+  const stored = window.localStorage.getItem(STORAGE_KEY) as CityValue | null;
+  return stored ?? 'moscow';
+}
+
+export function CityProvider({ children }: { children: ReactNode }) {
+  const [value, setValue] = useState<CityValue>(() => getInitialValue());
+
+  useEffect(() => {
+    window.localStorage.setItem(STORAGE_KEY, value);
+  }, [value]);
+
+  const cityName = useMemo(() => cityValueToName(value), [value]);
+
+  const contextValue = useMemo<CityContextValue>(
+    () => ({
+      value,
+      cityName,
+      setValue
+    }),
+    [cityName, value]
+  );
+
+  return <CityContext.Provider value={contextValue}>{children}</CityContext.Provider>;
+}
+
+export function useCity() {
+  const context = useContext(CityContext);
+  if (!context) {
+    throw new Error('useCity must be used within CityProvider');
+  }
+  return context;
+}
+
+export function CitySelect() {
+  const { value, setValue } = useCity();
+
+  return (
+    <label className="flex items-center gap-2 text-sm">
+      <span className="hidden font-medium sm:inline">Город</span>
+      <select
+        className={clsx(
+          'rounded-full border border-ink/10 bg-white px-4 py-2 text-sm shadow-soft transition hover:border-ink/20 focus:border-ink focus:outline-none focus:ring-2 focus:ring-ink/10'
+        )}
+        value={value}
+        onChange={(event) => setValue(event.target.value as CityValue)}
+      >
+        {CITY_OPTIONS.map((option) => (
+          <option key={option.value} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+
+export type { CityValue } from '@/lib/cities';

--- a/components/ui/empty-state.tsx
+++ b/components/ui/empty-state.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+import { Button } from '@/components/ui/button';
+
+type EmptyStateProps = {
+  title: string;
+  description?: string;
+  action?: ReactNode;
+};
+
+type EmptyStateComponent = ((props: EmptyStateProps) => JSX.Element) & {
+  ActionButton: typeof Button;
+};
+
+const EmptyStateBase = ({ title, description, action }: EmptyStateProps) => {
+  return (
+    <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-dashed border-ink/10 bg-white/60 p-10 text-center">
+      <h3 className="text-lg font-semibold">{title}</h3>
+      {description ? <p className="max-w-sm text-sm text-ink/70">{description}</p> : null}
+      {action}
+    </div>
+  );
+};
+
+export const EmptyState = EmptyStateBase as EmptyStateComponent;
+
+EmptyState.ActionButton = Button;

--- a/components/ui/loader.tsx
+++ b/components/ui/loader.tsx
@@ -1,0 +1,7 @@
+export function Loader() {
+  return (
+    <div className="flex items-center justify-center py-10">
+      <span className="h-12 w-12 animate-spin rounded-full border-4 border-ink/10 border-t-ink" aria-label="Загрузка" />
+    </div>
+  );
+}

--- a/components/ui/section.tsx
+++ b/components/ui/section.tsx
@@ -1,0 +1,25 @@
+import type { ReactNode } from 'react';
+
+export function Section({
+  title,
+  description,
+  children,
+  className
+}: {
+  title: string;
+  description?: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <section className={className}>
+      <div className="mb-6 flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold tracking-tight sm:text-3xl">{title}</h2>
+          {description ? <p className="mt-2 text-sm text-ink/70">{description}</p> : null}
+        </div>
+      </div>
+      {children}
+    </section>
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,65 @@
+const API_URLS = {
+  clubs: process.env.NEXT_PUBLIC_CLUBS_URL ?? '',
+  workouts: process.env.NEXT_PUBLIC_WORKOUTS_URL ?? '',
+  races: process.env.NEXT_PUBLIC_RACES_URL ?? '',
+  routes: process.env.NEXT_PUBLIC_ROUTES_URL ?? ''
+};
+
+export type DataKind = keyof typeof API_URLS;
+
+const USE_PROXY = process.env.NEXT_PUBLIC_HAS_NOCODB_TOKEN === '1';
+
+export function buildWhere(city?: string) {
+  if (!city) {
+    return undefined;
+  }
+  return `where=(city,eq,${encodeURIComponent(city)})`;
+}
+
+function withParams(url: string, params?: Record<string, string>) {
+  if (!params || Object.keys(params).length === 0) {
+    return url;
+  }
+  const searchParams = new URLSearchParams(params);
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}${searchParams.toString()}`;
+}
+
+export async function fetchJson<T = unknown>(url: string, params?: Record<string, string>): Promise<T> {
+  const target = withParams(url, params);
+  const response = await fetch(target);
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  return (await response.json()) as T;
+}
+
+export async function fetchRecords<T = unknown>(
+  kind: DataKind,
+  city?: string,
+  params: Record<string, string> = {}
+) : Promise<RecordListResponse<T>> {
+  const baseUrl = API_URLS[kind];
+  if (!baseUrl) {
+    throw new Error(`Отсутствует URL для ресурса ${kind}`);
+  }
+
+  const finalParams = { ...params };
+  const where = buildWhere(city);
+  if (where) {
+    finalParams.where = where;
+    if (!finalParams.limit) {
+      finalParams.limit = '100';
+    }
+  }
+
+  if (USE_PROXY) {
+    return fetchJson<RecordListResponse<T>>(`/api/noco`, { kind, ...finalParams });
+  }
+
+  return fetchJson<RecordListResponse<T>>(baseUrl, finalParams);
+}
+
+export type RecordListResponse<T> = {
+  list: T[];
+};

--- a/lib/cities.ts
+++ b/lib/cities.ts
@@ -1,0 +1,28 @@
+export type CityValue = 'moscow' | 'spb' | 'other';
+
+export const CITY_OPTIONS: { value: CityValue; label: string; cityName?: string }[] = [
+  { value: 'moscow', label: 'Москва', cityName: 'Москва' },
+  { value: 'spb', label: 'Санкт-Петербург', cityName: 'Санкт-Петербург' },
+  { value: 'other', label: 'Другие города' }
+];
+
+export const PRIMARY_CITIES = CITY_OPTIONS.filter((option) => option.cityName).map(
+  (option) => option.cityName as string
+);
+
+export function cityValueToName(value: CityValue) {
+  return CITY_OPTIONS.find((option) => option.value === value)?.cityName;
+}
+
+export function filterByCitySelection<T extends { city?: string | null }>(list: T[], value: CityValue) {
+  if (value === 'other') {
+    return list.filter((item) => !item.city || !PRIMARY_CITIES.includes(item.city));
+  }
+
+  const cityName = cityValueToName(value);
+  if (!cityName) {
+    return list;
+  }
+
+  return list.filter((item) => item.city === cityName);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,0 +1,39 @@
+export type ClubRecord = {
+  id: string | number;
+  name: string;
+  city: string;
+  photoUrl?: string;
+  description?: string;
+  instagram?: string;
+};
+
+export type WorkoutRecord = {
+  id: string | number;
+  title?: string;
+  date?: string;
+  city?: string;
+  distanceKm?: number;
+  paceMin?: number;
+  paceMax?: number;
+  location?: string;
+  isOpen?: boolean;
+  clubName?: string;
+};
+
+export type RaceRecord = {
+  id: string | number;
+  title: string;
+  city?: string;
+  date?: string;
+  distanceKm?: number;
+  url?: string;
+};
+
+export type RouteRecord = {
+  id: string | number;
+  title: string;
+  city?: string;
+  distanceKm?: number;
+  surface?: string;
+  description?: string;
+};

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,47 @@
+export function formatDate(value?: string) {
+  if (!value) return 'Дата уточняется';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat('ru-RU', {
+    day: 'numeric',
+    month: 'long'
+  }).format(parsed);
+}
+
+export function formatDateWithWeekday(value?: string) {
+  if (!value) return 'Дата уточняется';
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat('ru-RU', {
+    weekday: 'short',
+    day: 'numeric',
+    month: 'long'
+  }).format(parsed);
+}
+
+export function formatDistance(distance?: number | null) {
+  if (distance === undefined || distance === null) {
+    return null;
+  }
+  return `${distance.toString().replace('.', ',')} км`;
+}
+
+export function formatPace(min?: number | null, max?: number | null) {
+  if (min === undefined && max === undefined) {
+    return null;
+  }
+  if (min !== undefined && max !== undefined) {
+    return `${min}-${max} мин/км`;
+  }
+  if (min !== undefined) {
+    return `от ${min} мин/км`;
+  }
+  if (max !== undefined) {
+    return `до ${max} мин/км`;
+  }
+  return null;
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,15 @@
+const nextConfig = {
+  env: {
+    NEXT_PUBLIC_HAS_NOCODB_TOKEN: process.env.NOCODB_TOKEN ? '1' : ''
+  },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '**'
+      }
+    ]
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "runclubs-platform",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "format": "prettier --write ."
+  },
+  "dependencies": {
+    "clsx": "^2.1.0",
+    "next": "^14.2.5",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "swr": "^2.2.5"
+  },
+  "devDependencies": {
+    "@types/node": "^20.12.7",
+    "@types/react": "^18.2.56",
+    "@types/react-dom": "^18.2.19",
+    "autoprefixer": "^10.4.17",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "^14.2.5",
+    "postcss": "^8.4.35",
+    "prettier": "^3.2.5",
+    "tailwindcss": "^3.4.3",
+    "typescript": "^5.4.5"
+  }
+}

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="16" fill="#0077FF" />
+  <path d="M18 44L28 20h8l-6 16h16l-2 8H18z" fill="#F9F9F7" />
+</svg>

--- a/public/icon-192.svg
+++ b/public/icon-192.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="192" height="192" viewBox="0 0 256 256" fill="none">
+  <rect width="256" height="256" rx="56" fill="#111111" />
+  <path
+    fill="#B9FF66"
+    d="M92 64h64c40 0 68 22 68 64 0 28-14 48-36 58l28 74h-44l-24-64h-28v64H92V64Zm64 92c14 0 24-10 24-28 0-18-10-28-24-28h-28v56h28Z"
+  />
+</svg>

--- a/public/icon-512.svg
+++ b/public/icon-512.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 256 256" fill="none">
+  <rect width="256" height="256" rx="56" fill="#111111" />
+  <path
+    fill="#B9FF66"
+    d="M92 64h64c40 0 68 22 68 64 0 28-14 48-36 58l28 74h-44l-24-64h-28v64H92V64Zm64 92c14 0 24-10 24-28 0-18-10-28-24-28h-28v56h28Z"
+  />
+</svg>

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,52 @@
+const CACHE_NAME = 'runclubs-cache-v1';
+const OFFLINE_URLS = ['/'];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll(OFFLINE_URLS))
+      .then(() => self.skipWaiting())
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.map((key) => {
+          if (key !== CACHE_NAME) {
+            return caches.delete(key);
+          }
+          return undefined;
+        })
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  event.respondWith(
+    fetch(event.request)
+      .then((response) => {
+        const copy = response.clone();
+        caches.open(CACHE_NAME).then((cache) => cache.put(event.request, copy));
+        return response;
+      })
+      .catch(async () => {
+        const cached = await caches.match(event.request);
+        if (cached) {
+          return cached;
+        }
+        if (event.request.mode === 'navigate') {
+          return caches.match('/');
+        }
+        throw new Error('Network error');
+      })
+  );
+});

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,24 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./app/**/*.{ts,tsx}', './components/**/*.{ts,tsx}', './lib/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: '#F9F9F7',
+        accent: '#B9FF66',
+        accentBlue: '#0077FF',
+        ink: '#111111'
+      },
+      boxShadow: {
+        soft: '0 10px 30px rgba(17, 17, 17, 0.08)'
+      },
+      fontFamily: {
+        sans: ['var(--font-inter)']
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- replace PNG PWA icons with equivalent SVG assets to keep the repository binary-free
- update metadata and web manifest to reference the new SVG icons

## Testing
- npm install *(fails: registry returns HTTP 403 in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68d29df36c3883299a8ef7bbfc7377d0