### PR TITLE
feat: centralize RU copy + sections props

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,7 +21,7 @@ export default function HomePage() {
               {COPY.hero.tagline}
             </p>
           </div>
-          <dl className="grid grid-cols-2 gap-4 text-sm text-ink/70 md:w-72">
+          <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-2 text-sm text-ink/70 md:max-w-[26rem]">
             <div>
               <dt className="font-semibold text-ink">&gt;50 клубов</dt>
               <dd>{COPY.clubs.subtitle}</dd>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import { CTASection } from '@/components/sections/cta-section';
-import { COPY } from "@/content/ru";
+import { COPY } from '@/content/ru';
 import { RoutesSection } from '@/components/sections/routes-section';
 import { TopClubsSection } from '@/components/sections/top-clubs-section';
 import { UpcomingRacesSection } from '@/components/sections/upcoming-races-section';

--- a/components/sections/top-clubs-section.tsx
+++ b/components/sections/top-clubs-section.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react';
 import useSWR from 'swr';
+import { COPY } from '@/content/ru';
 import { ClubCard } from '@/components/cards/club-card';
 import { Loader } from '@/components/ui/loader';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -11,7 +12,15 @@ import { fetchRecords } from '@/lib/api';
 import { filterByCitySelection } from '@/lib/cities';
 import type { ClubRecord } from '@/lib/types';
 
-export function TopClubsSection() {
+type Props = {
+  title?: string;
+  subtitle?: string;
+};
+
+export function TopClubsSection({
+  title = COPY.clubs.title,
+  subtitle = COPY.clubs.subtitle,
+}: Props) {
   const { value, cityName } = useCity();
   const { data, error, isLoading } = useSWR(['clubs', value], async () => {
     const response = await fetchRecords<ClubRecord>('clubs', cityName ?? undefined);
@@ -24,7 +33,7 @@ export function TopClubsSection() {
   }, [data, value]);
 
   return (
-    <Section title="Топ клубов города" description="Отобранные комьюнити и проверенные тренеры">
+    <Section title={title} description={subtitle}>
       {isLoading ? <Loader /> : null}
       {error ? <EmptyState title="Не удалось загрузить клубы" description="Обновите страницу и попробуйте снова." /> : null}
       {!isLoading && !error ? (

--- a/components/sections/weekend-workouts-section.tsx
+++ b/components/sections/weekend-workouts-section.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo } from 'react';
 import useSWR from 'swr';
+import { COPY } from '@/content/ru';
 import { WorkoutCard } from '@/components/cards/workout-card';
 import { Loader } from '@/components/ui/loader';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -11,7 +12,15 @@ import { fetchRecords } from '@/lib/api';
 import { filterByCitySelection } from '@/lib/cities';
 import type { WorkoutRecord } from '@/lib/types';
 
-export function WeekendWorkoutsSection() {
+type Props = {
+  title?: string;
+  subtitle?: string;
+};
+
+export function WeekendWorkoutsSection({
+  title = COPY.events.title,
+  subtitle = COPY.events.subtitle,
+}: Props) {
   const { value, cityName } = useCity();
   const { data, error, isLoading } = useSWR(['workouts', value], async () => {
     const response = await fetchRecords<WorkoutRecord>('workouts', cityName ?? undefined);
@@ -24,7 +33,7 @@ export function WeekendWorkoutsSection() {
   }, [data, value]);
 
   return (
-    <Section title="Афиша выходных" description="Совместные забеги и тренировки ближайших выходных">
+    <Section title={title} description={subtitle}>
       {isLoading ? <Loader /> : null}
       {error ? <EmptyState title="Не удалось загрузить данные" description="Попробуйте обновить страницу." /> : null}
       {!isLoading && !error ? (

--- a/content/ru.ts
+++ b/content/ru.ts
@@ -1,4 +1,3 @@
-// content/ru.ts
 export const COPY = {
   hero: {
     tagline:


### PR DESCRIPTION
## Summary
- centralize homepage Russian copy in a shared content file
- pass section title and subtitle props to weekend workouts and top clubs sections
- update homepage hero and stats block to consume shared copy

## Testing
- npm run build *(fails: network access to download Inter font)*

------
https://chatgpt.com/codex/tasks/task_e_68d526d0f9ec8329adb80b407054bbfa