### PR TITLE
Harden submit forms and wire NocoDB + Resend notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,21 +14,25 @@ TypeScript и Tailwind CSS. Данные подгружаются из публ�
 
 ## Переменные окружения
 
-Создайте файл `.env` на основе примера:
-
-```bash
-cp .env.example .env
-```
-
-Список переменных:
+Публичные переменные для чтения каталогов:
 
 - `NEXT_PUBLIC_CLUBS_URL`
 - `NEXT_PUBLIC_WORKOUTS_URL`
 - `NEXT_PUBLIC_RACES_URL`
 - `NEXT_PUBLIC_ROUTES_URL`
-- `NEXT_PUBLIC_CLUB_FORM_URL`
-- `NEXT_PUBLIC_RUN_FORM_URL`
-- `NOCODB_TOKEN` (опционально, только если нужен приватный доступ к API)
+
+Серверные переменные для submit-форм:
+
+- `RESEND_API_KEY`
+- `EMAIL_TO`
+- `EMAIL_FROM`
+- `NOCODB_URL`
+- `NOCODB_TOKEN`
+- `NOCODB_CLUBS_TABLE_ID`
+- `NOCODB_WORKOUTS_TABLE_ID`
+
+> Важно: `NOCODB_CLUBS_TABLE_ID` и `NOCODB_WORKOUTS_TABLE_ID` должны быть ID таблиц NocoDB
+> (используются в `app/api/submit/club/route.ts` и `app/api/submit/run/route.ts`).
 
 ## Запуск локально
 
@@ -39,16 +43,17 @@ npm run dev
 
 Приложение будет доступно по адресу [http://localhost:3000](http://localhost:3000).
 
-## Сборка
+## Проверка сборки
 
 ```bash
 npm run build
 ```
 
-## Деплой на Vercel
+## Submit-формы
 
-1. Создайте новый проект в Vercel и подключите репозиторий.
-2. В разделе **Environment Variables** добавьте переменные из `.env`.
-3. Запустите деплой — Vercel автоматически соберёт и опубликует приложение.
-
-После деплоя убедитесь, что на главной странице отображаются данные и корректно работает фильтр города.
+- `/submit/club` — заявка на клуб.
+- `/submit/run` — заявка на открытую пробежку.
+- Обе формы валидируются на сервере, содержат honeypot-поле (`website`) и простое rate limiting по IP.
+- После успешной отправки:
+  1. создаётся запись в NocoDB;
+  2. отправляется email через Resend API.

--- a/app/api/submit/club/route.ts
+++ b/app/api/submit/club/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createNocoRecord, enforceRateLimit, getClientIp, sendResendEmail, validateClubPayload } from '@/lib/submit';
+
+export async function POST(request: NextRequest) {
+  const ip = getClientIp(request);
+  const rateLimit = enforceRateLimit(ip);
+  if (!rateLimit.ok) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429, headers: { 'Retry-After': String(rateLimit.retryAfter) } });
+  }
+
+  const body = await request.json();
+  if (body.website) return NextResponse.json({ ok: true });
+
+  const validated = validateClubPayload(body);
+  if (!validated.ok) return NextResponse.json({ errors: validated.errors }, { status: 400 });
+
+  await createNocoRecord(process.env.NOCODB_CLUBS_TABLE_ID, {
+    Name: validated.data.clubName,
+    City: validated.data.city,
+    ContactName: validated.data.contactName,
+    ContactEmail: validated.data.contactEmail,
+    Instagram: validated.data.instagram,
+    Description: validated.data.description
+    // TODO: Update keys above to exact NocoDB column names if schema differs.
+  });
+
+  await sendResendEmail(
+    `Новая заявка клуба: ${validated.data.clubName}`,
+    `<h2>Новый клуб</h2><p><b>Клуб:</b> ${validated.data.clubName}</p><p><b>Город:</b> ${validated.data.city}</p><p><b>Контакт:</b> ${validated.data.contactName}</p><p><b>Email:</b> ${validated.data.contactEmail}</p>`
+  );
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/submit/run/route.ts
+++ b/app/api/submit/run/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createNocoRecord, enforceRateLimit, getClientIp, sendResendEmail, validateRunPayload } from '@/lib/submit';
+
+export async function POST(request: NextRequest) {
+  const ip = getClientIp(request);
+  const rateLimit = enforceRateLimit(ip);
+  if (!rateLimit.ok) {
+    return NextResponse.json({ error: 'Too many requests' }, { status: 429, headers: { 'Retry-After': String(rateLimit.retryAfter) } });
+  }
+
+  const body = await request.json();
+  if (body.website) return NextResponse.json({ ok: true });
+
+  const validated = validateRunPayload(body);
+  if (!validated.ok) return NextResponse.json({ errors: validated.errors }, { status: 400 });
+
+  await createNocoRecord(process.env.NOCODB_WORKOUTS_TABLE_ID, {
+    Title: validated.data.title,
+    City: validated.data.city,
+    Date: validated.data.date,
+    Location: validated.data.location,
+    DistanceKm: validated.data.distanceKm,
+    PaceMin: validated.data.paceMin,
+    PaceMax: validated.data.paceMax,
+    Description: validated.data.description,
+    OrganizerName: validated.data.organizerName,
+    OrganizerEmail: validated.data.organizerEmail
+    // TODO: Update keys above to exact NocoDB column names if schema differs.
+  });
+
+  await sendResendEmail(
+    `Новая заявка пробежки: ${validated.data.title}`,
+    `<h2>Новая пробежка</h2><p><b>Название:</b> ${validated.data.title}</p><p><b>Город:</b> ${validated.data.city}</p><p><b>Дата:</b> ${validated.data.date}</p><p><b>Организатор:</b> ${validated.data.organizerName}</p><p><b>Email:</b> ${validated.data.organizerEmail}</p>`
+  );
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/submit/club/page.tsx
+++ b/app/submit/club/page.tsx
@@ -1,0 +1,5 @@
+import { ClubSubmitForm } from '@/components/forms/club-submit-form';
+
+export default function SubmitClubPage() {
+  return <ClubSubmitForm />;
+}

--- a/app/submit/run/page.tsx
+++ b/app/submit/run/page.tsx
@@ -1,0 +1,5 @@
+import { RunSubmitForm } from '@/components/forms/run-submit-form';
+
+export default function SubmitRunPage() {
+  return <RunSubmitForm />;
+}

--- a/components/forms/club-submit-form.tsx
+++ b/components/forms/club-submit-form.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useState } from 'react';
+
+type Errors = Record<string, string>;
+
+export function ClubSubmitForm() {
+  const [errors, setErrors] = useState<Errors>({});
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+
+  async function onSubmit(formData: FormData) {
+    const payload = Object.fromEntries(formData.entries());
+    setStatus('loading');
+    setErrors({});
+    const resp = await fetch('/api/submit/club', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    const data = await resp.json();
+    if (!resp.ok) {
+      setErrors(data.errors ?? { form: data.error ?? 'Ошибка отправки' });
+      setStatus('error');
+      return;
+    }
+
+    setStatus('success');
+  }
+
+  return (
+    <form action={onSubmit} className="space-y-4 rounded-3xl bg-white p-6 shadow-soft">
+      <h1 className="text-3xl font-semibold">Заявка на добавление клуба</h1>
+      <Input name="clubName" label="Название клуба" error={errors.clubName} required />
+      <Input name="city" label="Город" error={errors.city} required />
+      <Input name="contactName" label="Контактное имя" error={errors.contactName} required />
+      <Input name="contactEmail" label="Email" type="email" error={errors.contactEmail} required />
+      <Input name="instagram" label="Instagram (ссылка)" error={errors.instagram} />
+      <TextArea name="description" label="Описание" error={errors.description} />
+      <input type="text" name="website" className="hidden" tabIndex={-1} autoComplete="off" />
+      <button className="rounded-xl bg-ink px-4 py-2 text-white" disabled={status === 'loading'}>
+        {status === 'loading' ? 'Отправка...' : 'Отправить заявку'}
+      </button>
+      {errors.form && <p className="text-sm text-red-600">{errors.form}</p>}
+      {status === 'success' && <p className="text-sm text-green-700">Спасибо! Заявка отправлена.</p>}
+    </form>
+  );
+}
+
+function Input({ name, label, error, required, type = 'text' }: { name: string; label: string; error?: string; required?: boolean; type?: string }) {
+  return <label className="block text-sm"><span className="mb-1 block font-medium">{label}</span><input name={name} type={type} required={required} className="w-full rounded-xl border border-neutral-300 px-3 py-2" />{error && <span className="text-red-600">{error}</span>}</label>;
+}
+
+function TextArea({ name, label, error }: { name: string; label: string; error?: string }) {
+  return <label className="block text-sm"><span className="mb-1 block font-medium">{label}</span><textarea name={name} rows={5} className="w-full rounded-xl border border-neutral-300 px-3 py-2" />{error && <span className="text-red-600">{error}</span>}</label>;
+}

--- a/components/forms/run-submit-form.tsx
+++ b/components/forms/run-submit-form.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useState } from 'react';
+
+type Errors = Record<string, string>;
+
+export function RunSubmitForm() {
+  const [errors, setErrors] = useState<Errors>({});
+  const [status, setStatus] = useState<'idle' | 'loading' | 'success' | 'error'>('idle');
+
+  async function onSubmit(formData: FormData) {
+    const payload = Object.fromEntries(formData.entries());
+    setStatus('loading');
+    setErrors({});
+    const resp = await fetch('/api/submit/run', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+    const data = await resp.json();
+
+    if (!resp.ok) {
+      setErrors(data.errors ?? { form: data.error ?? 'Ошибка отправки' });
+      setStatus('error');
+      return;
+    }
+
+    setStatus('success');
+  }
+
+  return (
+    <form action={onSubmit} className="space-y-4 rounded-3xl bg-white p-6 shadow-soft">
+      <h1 className="text-3xl font-semibold">Предложить пробежку</h1>
+      <Input name="title" label="Название" error={errors.title} required />
+      <Input name="city" label="Город" error={errors.city} required />
+      <Input name="date" label="Дата" type="date" error={errors.date} required />
+      <Input name="location" label="Место сбора" error={errors.location} required />
+      <Input name="distanceKm" label="Дистанция (км)" type="number" error={errors.distanceKm} />
+      <Input name="paceMin" label="Темп от (мин/км)" type="number" error={errors.paceMin} />
+      <Input name="paceMax" label="Темп до (мин/км)" type="number" error={errors.paceMax} />
+      <Input name="organizerName" label="Ваше имя" error={errors.organizerName} required />
+      <Input name="organizerEmail" label="Email" type="email" error={errors.organizerEmail} required />
+      <TextArea name="description" label="Описание" error={errors.description} />
+      <input type="text" name="website" className="hidden" tabIndex={-1} autoComplete="off" />
+      <button className="rounded-xl bg-ink px-4 py-2 text-white" disabled={status === 'loading'}>{status === 'loading' ? 'Отправка...' : 'Отправить заявку'}</button>
+      {errors.form && <p className="text-sm text-red-600">{errors.form}</p>}
+      {status === 'success' && <p className="text-sm text-green-700">Спасибо! Заявка отправлена.</p>}
+    </form>
+  );
+}
+
+function Input({ name, label, error, required, type = 'text' }: { name: string; label: string; error?: string; required?: boolean; type?: string }) {
+  return <label className="block text-sm"><span className="mb-1 block font-medium">{label}</span><input name={name} type={type} required={required} className="w-full rounded-xl border border-neutral-300 px-3 py-2" />{error && <span className="text-red-600">{error}</span>}</label>;
+}
+
+function TextArea({ name, label, error }: { name: string; label: string; error?: string }) {
+  return <label className="block text-sm"><span className="mb-1 block font-medium">{label}</span><textarea name={name} rows={5} className="w-full rounded-xl border border-neutral-300 px-3 py-2" />{error && <span className="text-red-600">{error}</span>}</label>;
+}

--- a/components/sections/cta-section.tsx
+++ b/components/sections/cta-section.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 
-const clubFormUrl = process.env.NEXT_PUBLIC_CLUB_FORM_URL ?? '#';
-const runFormUrl = process.env.NEXT_PUBLIC_RUN_FORM_URL ?? '#';
+const clubFormUrl = '/submit/club';
+const runFormUrl = '/submit/run';
 
 export function CTASection() {
   return (
@@ -17,7 +17,7 @@ export function CTASection() {
         </div>
         <div className="flex flex-wrap gap-3">
           <Button asChild>
-            <Link href={clubFormUrl} target="_blank" rel="noopener noreferrer">
+            <Link href={clubFormUrl}>
               Заявка на клуб
             </Link>
           </Button>
@@ -26,7 +26,7 @@ export function CTASection() {
             variant="ghost"
             className="border border-white/30 text-background hover:bg-white/10"
           >
-            <Link href={runFormUrl} target="_blank" rel="noopener noreferrer">
+            <Link href={runFormUrl}>
               Предложить пробежку
             </Link>
           </Button>

--- a/lib/submit.ts
+++ b/lib/submit.ts
@@ -1,0 +1,158 @@
+import { NextRequest } from 'next/server';
+
+const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
+const RATE_LIMIT_MAX_REQUESTS = 5;
+
+const ipStore = new Map<string, { count: number; expiresAt: number }>();
+
+export function getClientIp(request: NextRequest) {
+  const forwarded = request.headers.get('x-forwarded-for');
+  if (forwarded) return forwarded.split(',')[0]?.trim() ?? 'unknown';
+  const realIp = request.headers.get('x-real-ip');
+  return realIp ?? 'unknown';
+}
+
+export function enforceRateLimit(ip: string) {
+  const now = Date.now();
+  const hit = ipStore.get(ip);
+
+  if (!hit || hit.expiresAt <= now) {
+    ipStore.set(ip, { count: 1, expiresAt: now + RATE_LIMIT_WINDOW_MS });
+    return { ok: true as const };
+  }
+
+  if (hit.count >= RATE_LIMIT_MAX_REQUESTS) {
+    return { ok: false as const, retryAfter: Math.ceil((hit.expiresAt - now) / 1000) };
+  }
+
+  hit.count += 1;
+  return { ok: true as const };
+}
+
+function normalizeText(value: unknown) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export type ClubSubmitPayload = {
+  clubName: string;
+  city: string;
+  contactName: string;
+  contactEmail: string;
+  instagram?: string;
+  description?: string;
+};
+
+export type RunSubmitPayload = {
+  title: string;
+  city: string;
+  date: string;
+  location: string;
+  distanceKm?: number;
+  paceMin?: number;
+  paceMax?: number;
+  description?: string;
+  organizerName: string;
+  organizerEmail: string;
+};
+
+const emailRe = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const igRe = /^(https?:\/\/)?(www\.)?instagram\.com\/[A-Za-z0-9._-]+\/?$/i;
+
+export function validateClubPayload(raw: unknown) {
+  const body = (raw ?? {}) as Record<string, unknown>;
+  const errors: Record<string, string> = {};
+
+  const clubName = normalizeText(body.clubName);
+  const city = normalizeText(body.city);
+  const contactName = normalizeText(body.contactName);
+  const contactEmail = normalizeText(body.contactEmail);
+  const instagram = normalizeText(body.instagram);
+  const description = normalizeText(body.description);
+
+  if (!clubName || clubName.length < 2) errors.clubName = 'Название клуба должно быть не короче 2 символов';
+  if (!city || city.length < 2) errors.city = 'Укажите город';
+  if (!contactName || contactName.length < 2) errors.contactName = 'Укажите контактное имя';
+  if (!emailRe.test(contactEmail)) errors.contactEmail = 'Некорректный email';
+  if (instagram && !igRe.test(instagram)) errors.instagram = 'Укажите ссылку на Instagram профиля';
+  if (description.length > 1500) errors.description = 'Описание слишком длинное';
+
+  return { ok: Object.keys(errors).length === 0, errors, data: { clubName, city, contactName, contactEmail, instagram: instagram || undefined, description: description || undefined } as ClubSubmitPayload };
+}
+
+export function validateRunPayload(raw: unknown) {
+  const body = (raw ?? {}) as Record<string, unknown>;
+  const errors: Record<string, string> = {};
+
+  const title = normalizeText(body.title);
+  const city = normalizeText(body.city);
+  const date = normalizeText(body.date);
+  const location = normalizeText(body.location);
+  const description = normalizeText(body.description);
+  const organizerName = normalizeText(body.organizerName);
+  const organizerEmail = normalizeText(body.organizerEmail);
+  const distanceKm = body.distanceKm === '' || body.distanceKm == null ? undefined : Number(body.distanceKm);
+  const paceMin = body.paceMin === '' || body.paceMin == null ? undefined : Number(body.paceMin);
+  const paceMax = body.paceMax === '' || body.paceMax == null ? undefined : Number(body.paceMax);
+
+  if (!title || title.length < 2) errors.title = 'Укажите название пробежки';
+  if (!city || city.length < 2) errors.city = 'Укажите город';
+  if (!date) errors.date = 'Укажите дату';
+  if (!location || location.length < 2) errors.location = 'Укажите место сбора';
+  if (!organizerName || organizerName.length < 2) errors.organizerName = 'Укажите ваше имя';
+  if (!emailRe.test(organizerEmail)) errors.organizerEmail = 'Некорректный email';
+  if (description.length > 1500) errors.description = 'Описание слишком длинное';
+
+  if (distanceKm != null && (!Number.isFinite(distanceKm) || distanceKm <= 0 || distanceKm > 200)) errors.distanceKm = 'Дистанция должна быть от 0 до 200 км';
+  if (paceMin != null && (!Number.isFinite(paceMin) || paceMin <= 0 || paceMin > 20)) errors.paceMin = 'Темп должен быть в мин/км';
+  if (paceMax != null && (!Number.isFinite(paceMax) || paceMax <= 0 || paceMax > 20)) errors.paceMax = 'Темп должен быть в мин/км';
+  if (paceMin != null && paceMax != null && paceMin > paceMax) errors.paceMax = 'Максимальный темп должен быть больше минимального';
+
+  return { ok: Object.keys(errors).length === 0, errors, data: { title, city, date, location, description: description || undefined, organizerName, organizerEmail, distanceKm, paceMin, paceMax } as RunSubmitPayload };
+}
+
+export async function sendResendEmail(subject: string, html: string) {
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = process.env.EMAIL_FROM;
+  const to = process.env.EMAIL_TO;
+
+  if (!apiKey || !from || !to) {
+    throw new Error('Email env vars are missing');
+  }
+
+  const resp = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ from, to: [to], subject, html })
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`Resend error: ${resp.status} ${text}`);
+  }
+}
+
+export async function createNocoRecord(tableId: string | undefined, payload: Record<string, unknown>) {
+  const url = process.env.NOCODB_URL;
+  const token = process.env.NOCODB_TOKEN;
+  if (!url || !token || !tableId) {
+    throw new Error('NocoDB env vars are missing');
+  }
+
+  const target = `${url.replace(/\/$/, '')}/api/v2/tables/${tableId}/records`;
+  const resp = await fetch(target, {
+    method: 'POST',
+    headers: {
+      'xc-token': token,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  });
+
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`NocoDB error: ${resp.status} ${text}`);
+  }
+}


### PR DESCRIPTION
### Motivation
- Prevent garbage and spam submissions by validating inputs, adding a honeypot and simple rate limiting. 
- Persist incoming submissions to NocoDB and deliver notification emails via Resend from server-side code so secrets are not exposed to the client. 
- Keep existing UI visually unchanged while replacing external CTA links with internal submit pages. 

### Description
- Replace CTA external URLs with internal routes and add pages ` /submit/club` and `/submit/run` that render new client form components (`components/forms/club-submit-form.tsx` and `components/forms/run-submit-form.tsx`).
- Add server API endpoints `POST /api/submit/club` and `POST /api/submit/run` that perform honeypot check (`website`), per-IP in-memory rate limiting, payload validation, NocoDB persistence, and Resend email notification. (files: `app/api/submit/club/route.ts`, `app/api/submit/run/route.ts`).
- Implement shared server utilities in `lib/submit.ts` including validation (field-level checks), `getClientIp`, `enforceRateLimit`, `createNocoRecord` (NocoDB), and `sendResendEmail` (Resend HTTP API). Secrets are read server-side via env vars and are not exposed to the client.
- Document required server env variables and TODOs for NocoDB table ID/column mapping in `README.md` (add `RESEND_API_KEY`, `EMAIL_TO`, `EMAIL_FROM`, `NOCODB_URL`, `NOCODB_TOKEN`, `NOCODB_CLUBS_TABLE_ID`, `NOCODB_WORKOUTS_TABLE_ID`).

### Testing
- Branch creation and commit: `git checkout -b feat/forms-hardening` and commit of changes succeeded. (success)
- Attempted to install `zod` and `resend` via `npm install` failed due to registry permissions (HTTP 403) in this environment; consequently validation is implemented inline in `lib/submit.ts` instead of using `zod`. (failed)
- `npm run build` was executed and failed in this environment because Next.js could not fetch the Google Font (`Inter`) during build, an unrelated network/font issue; the submit-related code is committed but full production build could not be verified here. (failed)
- No additional automated integration tests were run in this environment; to validate endpoints locally run the dev server with required env vars and exercise the forms (see README for local testing instructions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a099827257c8329973ece9dafab8812)