### PR TITLE
Fix build and harden submit APIs before merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ cp .env.example .env
 - `NEXT_PUBLIC_CLUB_FORM_URL`
 - `NEXT_PUBLIC_RUN_FORM_URL`
 - `NOCODB_TOKEN` (опционально, только если нужен приватный доступ к API)
+- `NOCODB_CLUB_SUBMIT_URL` (endpoint для POST заявок клуба)
+- `NOCODB_RUN_SUBMIT_URL` (endpoint для POST заявок пробежек)
+- `RESEND_API_KEY` (API ключ Resend для email-уведомлений)
+- `RESEND_FROM` (email отправителя, подтвержденный в Resend)
+- `RESEND_TO` (email получателя уведомлений)
 
 ## Запуск локально
 

--- a/app/api/submit/club/route.ts
+++ b/app/api/submit/club/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { isValidSocialLink, postToNocoDB, safeServerErrorLog, sendResendNotification } from '@/lib/server/submit';
+
+export async function POST(request: Request) {
+  let body: Record<string, unknown>;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Некорректный JSON' }, { status: 400 });
+  }
+
+  const name = typeof body.name === 'string' ? body.name.trim() : '';
+  const city = typeof body.city === 'string' ? body.city.trim() : '';
+  const socialLink = typeof body.socialLink === 'string' ? body.socialLink.trim() : '';
+
+  if (!name || !city || !socialLink) {
+    return NextResponse.json({ error: 'Заполните обязательные поля' }, { status: 400 });
+  }
+
+  if (!isValidSocialLink(socialLink)) {
+    return NextResponse.json({ error: 'Укажите корректную ссылку (instagram, t.me, strava или https URL)' }, { status: 400 });
+  }
+
+  try {
+    await postToNocoDB({ ...body, socialLink }, 'NOCODB_CLUB_SUBMIT_URL');
+  } catch (error) {
+    safeServerErrorLog('submit-club:nocodb', error);
+    return NextResponse.json({ error: 'Не удалось сохранить заявку. Попробуйте позже.' }, { status: 502 });
+  }
+
+  try {
+    await sendResendNotification({
+      from: process.env.RESEND_FROM,
+      to: [process.env.RESEND_TO],
+      subject: 'Новая заявка на клуб',
+      text: `Клуб: ${name}\nГород: ${city}\nСсылка: ${socialLink}`
+    });
+  } catch (error) {
+    safeServerErrorLog('submit-club:resend', error);
+    return NextResponse.json({ error: 'Заявка сохранена, но уведомление не отправлено.' }, { status: 202 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/submit/run/route.ts
+++ b/app/api/submit/run/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server';
+import { isValidSocialLink, postToNocoDB, safeServerErrorLog, sendResendNotification } from '@/lib/server/submit';
+
+export async function POST(request: Request) {
+  let body: Record<string, unknown>;
+
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Некорректный JSON' }, { status: 400 });
+  }
+
+  const title = typeof body.title === 'string' ? body.title.trim() : '';
+  const city = typeof body.city === 'string' ? body.city.trim() : '';
+  const socialLink = typeof body.socialLink === 'string' ? body.socialLink.trim() : '';
+
+  if (!title || !city || !socialLink) {
+    return NextResponse.json({ error: 'Заполните обязательные поля' }, { status: 400 });
+  }
+
+  if (!isValidSocialLink(socialLink)) {
+    return NextResponse.json({ error: 'Укажите корректную ссылку (instagram, t.me, strava или https URL)' }, { status: 400 });
+  }
+
+  try {
+    await postToNocoDB({ ...body, socialLink }, 'NOCODB_RUN_SUBMIT_URL');
+  } catch (error) {
+    safeServerErrorLog('submit-run:nocodb', error);
+    return NextResponse.json({ error: 'Не удалось сохранить заявку. Попробуйте позже.' }, { status: 502 });
+  }
+
+  try {
+    await sendResendNotification({
+      from: process.env.RESEND_FROM,
+      to: [process.env.RESEND_TO],
+      subject: 'Новая заявка на пробежку',
+      text: `Пробежка: ${title}\nГород: ${city}\nСсылка: ${socialLink}`
+    });
+  } catch (error) {
+    safeServerErrorLog('submit-run:resend', error);
+    return NextResponse.json({ error: 'Заявка сохранена, но уведомление не отправлено.' }, { status: 202 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,14 +1,8 @@
 import type { Metadata } from 'next';
 import type { ReactNode } from 'react';
-import { Inter } from 'next/font/google';
 import './globals.css';
 import { Providers } from '@/components/providers/providers';
 import { Header } from '@/components/layout/header';
-
-const inter = Inter({
-  subsets: ['latin', 'cyrillic'],
-  variable: '--font-inter'
-});
 
 export const metadata: Metadata = {
   title: 'RunClubs — беговые клубы и тренировки',
@@ -47,7 +41,7 @@ export default function RootLayout({
   children: ReactNode;
 }) {
   return (
-    <html lang="ru" className={inter.variable}>
+    <html lang="ru">
       <body>
         <Providers>
           <Header />

--- a/lib/server/submit.ts
+++ b/lib/server/submit.ts
@@ -1,0 +1,61 @@
+const SOCIAL_LINK_RE = /^(https:\/\/)?(www\.)?(instagram\.com|t\.me|strava\.com)\/.+/i;
+
+export function isValidSocialLink(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+
+  try {
+    const url = new URL(trimmed.startsWith('http') ? trimmed : `https://${trimmed}`);
+    if (url.protocol !== 'https:') return false;
+    return true;
+  } catch {
+    return SOCIAL_LINK_RE.test(trimmed);
+  }
+}
+
+export function safeServerErrorLog(context: string, error: unknown) {
+  const message = error instanceof Error ? error.message : 'Unknown error';
+  console.error(`[${context}] ${message}`);
+}
+
+export async function postToNocoDB(body: Record<string, unknown>, targetEnv: string) {
+  const endpoint = process.env[targetEnv];
+  if (!endpoint) {
+    throw new Error(`${targetEnv} is not configured`);
+  }
+
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body)
+  });
+
+  if (!response.ok) {
+    throw new Error(`NocoDB request failed with status ${response.status}`);
+  }
+
+  return response;
+}
+
+export async function sendResendNotification(payload: Record<string, unknown>) {
+  const apiKey = process.env.RESEND_API_KEY;
+  const to = process.env.RESEND_TO;
+  const from = process.env.RESEND_FROM;
+
+  if (!apiKey || !to || !from) {
+    throw new Error('Resend environment variables are not configured');
+  }
+
+  const response = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    throw new Error(`Resend request failed with status ${response.status}`);
+  }
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -4,7 +4,7 @@ export type ClubRecord = {
   city: string;
   photoUrl?: string;
   description?: string;
-  instagram?: string;
+  socialLink?: string;
 };
 
 export type WorkoutRecord = {


### PR DESCRIPTION
### Motivation
- Prevent production `next build` from failing due to external Google Fonts fetch and make submit endpoints robust against downstream failures.
- Ensure submit APIs never crash on bad input or network errors and return graceful JSON errors for Resend/NocoDB failures.
- Align server types and validation to accept general social links (Instagram/Telegram/Strava/HTTPS) using a single `socialLink` field.

### Description
- Removed runtime Google Fonts network dependency from `app/layout.tsx` so the build no longer fails when external font fetch is unavailable.
- Added server helpers in `lib/server/submit.ts` implementing `isValidSocialLink`, `postToNocoDB`, `sendResendNotification`, and `safeServerErrorLog` for centralized validation, posting, notification, and safe error logging.
- Implemented defensive submit endpoints `POST /api/submit/club` and `POST /api/submit/run` in `app/api/submit/club/route.ts` and `app/api/submit/run/route.ts` with guarded JSON parsing, required-field checks, social-link validation, and try/catch paths that return graceful JSON errors for NocoDB (502) and Resend (202) failures.
- Renamed the club field in shared types from `instagram` to `socialLink` in `lib/types.ts` and updated README environment variable instructions in `README.md` for the NocoDB submit URLs and Resend credentials.

### Testing
- Ran `npm run build` and the build completed successfully with generated routes including `/api/submit/club` and `/api/submit/run`.
- The build emitted non-blocking Next.js metadata warnings about `themeColor` placement, but these do not block the build and are informational only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a099f66afb88329b96b4152c423fafa)