### PR TITLE
Fix CTA links to internal submit pages

### DIFF
--- a/components/catalog/clubs-catalog.tsx
+++ b/components/catalog/clubs-catalog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
+import Link from 'next/link';
 import useSWR from 'swr';
 import { ClubCard } from '@/components/cards/club-card';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -10,7 +11,7 @@ import { fetchRecords } from '@/lib/api';
 import { filterByCitySelection } from '@/lib/cities';
 import type { ClubRecord } from '@/lib/types';
 
-const clubFormUrl = process.env.NEXT_PUBLIC_CLUB_FORM_URL ?? '#';
+const clubFormUrl = '/submit/club';
 
 export function ClubsCatalog() {
   const { value, cityName } = useCity();
@@ -39,9 +40,9 @@ export function ClubsCatalog() {
         description="Мы еще не знаем клубов в этом городе. Оставьте заявку, чтобы появиться первыми."
         action={
           <EmptyState.ActionButton asChild>
-            <a href={clubFormUrl} target="_blank" rel="noopener noreferrer">
+            <Link href={clubFormUrl}>
               Добавить клуб
-            </a>
+            </Link>
           </EmptyState.ActionButton>
         }
       />

--- a/components/catalog/routes-catalog.tsx
+++ b/components/catalog/routes-catalog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
+import Link from 'next/link';
 import useSWR from 'swr';
 import { RouteCard } from '@/components/cards/route-card';
 import { EmptyState } from '@/components/ui/empty-state';
@@ -10,7 +11,7 @@ import { fetchRecords } from '@/lib/api';
 import { filterByCitySelection } from '@/lib/cities';
 import type { RouteRecord } from '@/lib/types';
 
-const runFormUrl = process.env.NEXT_PUBLIC_RUN_FORM_URL ?? '#';
+const runFormUrl = '/submit/run';
 
 export function RoutesCatalog() {
   const { value, cityName } = useCity();
@@ -39,9 +40,9 @@ export function RoutesCatalog() {
         description="Расскажите о своей пробежке и помогите бегунам открыть новое место."
         action={
           <EmptyState.ActionButton asChild>
-            <a href={runFormUrl} target="_blank" rel="noopener noreferrer">
+            <Link href={runFormUrl}>
               Поделиться маршрутом
-            </a>
+            </Link>
           </EmptyState.ActionButton>
         }
       />

--- a/components/catalog/workouts-catalog.tsx
+++ b/components/catalog/workouts-catalog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import Link from 'next/link';
 import useSWR from 'swr';
 import { WorkoutCard } from '@/components/cards/workout-card';
 import { Button } from '@/components/ui/button';
@@ -11,7 +12,7 @@ import { fetchRecords } from '@/lib/api';
 import { filterByCitySelection } from '@/lib/cities';
 import type { WorkoutRecord } from '@/lib/types';
 
-const runFormUrl = process.env.NEXT_PUBLIC_RUN_FORM_URL ?? '#';
+const runFormUrl = '/submit/run';
 
 export function WorkoutsCatalog() {
   const [onlyOpen, setOnlyOpen] = useState(false);
@@ -56,9 +57,9 @@ export function WorkoutsCatalog() {
             description="Расскажите о своей пробежке, чтобы попасть в афишу."
             action={
               <EmptyState.ActionButton asChild>
-                <a href={runFormUrl} target="_blank" rel="noopener noreferrer">
+                <Link href={runFormUrl}>
                   Предложить тренировку
-                </a>
+                </Link>
               </EmptyState.ActionButton>
             }
           />

--- a/components/sections/cta-section.tsx
+++ b/components/sections/cta-section.tsx
@@ -1,8 +1,8 @@
 import Link from 'next/link';
 import { Button } from '@/components/ui/button';
 
-const clubFormUrl = process.env.NEXT_PUBLIC_CLUB_FORM_URL ?? '#';
-const runFormUrl = process.env.NEXT_PUBLIC_RUN_FORM_URL ?? '#';
+const clubFormUrl = '/submit/club';
+const runFormUrl = '/submit/run';
 
 export function CTASection() {
   return (
@@ -17,7 +17,7 @@ export function CTASection() {
         </div>
         <div className="flex flex-wrap gap-3">
           <Button asChild>
-            <Link href={clubFormUrl} target="_blank" rel="noopener noreferrer">
+            <Link href={clubFormUrl}>
               Заявка на клуб
             </Link>
           </Button>
@@ -26,7 +26,7 @@ export function CTASection() {
             variant="ghost"
             className="border border-white/30 text-background hover:bg-white/10"
           >
-            <Link href={runFormUrl} target="_blank" rel="noopener noreferrer">
+            <Link href={runFormUrl}>
               Предложить пробежку
             </Link>
           </Button>


### PR DESCRIPTION
### Motivation
- Migrate CTA buttons from external NocoDB form URLs to the new internal submit pages so users reach the in-app flows instead of the old forms. 
- Ensure internal navigation does not open new tabs for these flows and retains existing visual styles. 
- Cover common CTAs and catalog empty-state actions where those form links were used.

### Description
- Replaced env-based external form URLs with internal routes: set `clubFormUrl` to `/submit/club` and `runFormUrl` to `/submit/run` in the CTA and catalog components. 
- Removed `target="_blank"` and `rel="noopener noreferrer"` for these links and switched catalog anchor tags to Next.js `Link` for client navigation. 
- Added `import Link from 'next/link'` where needed and kept all styling and button components unchanged. 

### Testing
- Searched for affected strings with `rg` to verify locations and replacements were applied. 
- Ran `npm run build` which completed successfully with type checking and production build (only non-blocking Next.js metadata warnings reported). 
- Confirmed updated components compile and the app build finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09b967d01c8329b8e1ad1946f2b9b6)