### PR TITLE
Hard-fix submit CTAs to internal routes and improve dark-theme visibility

### DIFF
--- a/components/sections/cta-section.tsx
+++ b/components/sections/cta-section.tsx
@@ -23,8 +23,8 @@ export function CTASection() {
           </Button>
           <Button
             asChild
-            variant="ghost"
-            className="border border-white/30 text-background hover:bg-white/10"
+            variant="outline"
+            className="border-white bg-white text-ink hover:bg-white/90"
           >
             <Link href={runFormUrl}>
               Предложить пробежку


### PR DESCRIPTION
### Motivation
- Ensure no public UI links point to the old external NocoDB forms and make the secondary CTA readable on dark backgrounds.

### Description
- No legacy `NocoDB` URLs needed removal because public CTAs already point to internal routes; updated the secondary CTA styling to a high-contrast white filled style in `components/sections/cta-section.tsx` and verified there are no `target="_blank"` internal submit links; files referencing the internal submit routes include `components/sections/cta-section.tsx`, `components/catalog/clubs-catalog.tsx`, `components/catalog/workouts-catalog.tsx`, and `components/catalog/routes-catalog.tsx`.

### Testing
- Searched the codebase for `NEXT_PUBLIC_CLUB_FORM_URL`, `NEXT_PUBLIC_RUN_FORM_URL`, `app.nocodb.com`, `Заявка на клуб`, and `Предложить пробежку` with `rg` and confirmed no public legacy links were present; built the app with `npm run build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aee6d571483298f9a0b4214927906)